### PR TITLE
ProductUpdate should use source_variant_id

### DIFF
--- a/api.json
+++ b/api.json
@@ -2588,7 +2588,7 @@
           "description": "The ID that can be used to reference a product in another system.",
           "type": "string"
         },
-        "variant_source_id": {
+        "source_variant_id": {
           "description": "Reference ID to an external object. Should be POSTed as `source_variant_id`.",
           "type": "string"
         },


### PR DESCRIPTION
Hi 

As discussed with Sung Min in support (#467379).  We needed to update the ProductUpdate endpoint so post the correct source_variant_id field, otherwise the generated code doesn't work.

regards

Steve